### PR TITLE
umask 0077

### DIFF
--- a/bin/gen-netrc.sh
+++ b/bin/gen-netrc.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+umask 0077
 cat >> ~/.netrc << EOF
 machine api.heroku.com
   login $HEROKU_TOOLBELT_API_EMAIL


### PR DESCRIPTION
It may be worth while making sure that the permission for the created `.netrc` file is correct.

Currently, umask is set to 0022 on Private Spaces while 0077 on Common Runtime. This difference may break some apps. While Private Spaces may change its behavior in the future, it should still be worthwhile making sure of permission of the created file.